### PR TITLE
feat: Phase 1 2차 프론트엔드 구현 (장바구니 + 좌석 + 결제 +  마이티켓)

### DIFF
--- a/src/api/mock/seats.mock.ts
+++ b/src/api/mock/seats.mock.ts
@@ -1,0 +1,58 @@
+import type { Seat, SeatSection } from '@/types/seat'
+
+function generateSeats(
+  sectionId: string,
+  gradeId: string,
+  rows: string[],
+  seatsPerRow: number,
+  startX: number,
+  startY: number,
+  soldRatio: number
+): Seat[] {
+  const seats: Seat[] = []
+  rows.forEach((row, ri) => {
+    for (let i = 1; i <= seatsPerRow; i++) {
+      const rand = Math.random()
+      let status: Seat['status'] = 'available'
+      if (rand < soldRatio) status = 'sold'
+      else if (rand < soldRatio + 0.05) status = 'held'
+
+      seats.push({
+        id: `${sectionId}-${row}${i}`,
+        section: sectionId,
+        row,
+        number: i,
+        gradeId,
+        status,
+        x: startX + (i - 1) * 28,
+        y: startY + ri * 28,
+      })
+    }
+  })
+  return seats
+}
+
+export function getMockSeatSections(): SeatSection[] {
+  return [
+    {
+      id: 'vip',
+      label: 'VIP',
+      seats: generateSeats('vip', 'vip', ['A', 'B', 'C'], 16, 120, 80, 0.7),
+    },
+    {
+      id: 'r',
+      label: 'R석',
+      seats: generateSeats('r', 'r', ['D', 'E', 'F', 'G'], 20, 64, 170, 0.4),
+    },
+    {
+      id: 's',
+      label: 'S석',
+      seats: generateSeats('s', 's', ['H', 'I', 'J', 'K', 'L'], 24, 8, 290, 0.2),
+    },
+    {
+      id: 'a',
+      label: 'A석',
+      seats: generateSeats('a', 'a', ['M', 'N', 'O'], 24, 8, 440, 0.1),
+    },
+  ]
+}

--- a/src/api/reservation.api.ts
+++ b/src/api/reservation.api.ts
@@ -1,0 +1,62 @@
+import type { Reservation, TrackType } from '@/types/reservation'
+import client from './client'
+
+const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true'
+
+let mockTickets: Reservation[] = []
+
+export const reservationApi = {
+  async create(params: {
+    concertId: string
+    concertTitle: string
+    dateId: string
+    track: TrackType
+    gradeId: string
+    gradeLabel: string
+    unitPrice: number
+    quantity: number
+    seatId?: string
+  }): Promise<Reservation> {
+    if (USE_MOCK) {
+      const timeoutMinutes = params.track === 'cart' ? 5 : 10
+      const reservation: Reservation = {
+        id: `rsv-${Date.now()}`,
+        concertId: params.concertId,
+        concertTitle: params.concertTitle,
+        dateId: params.dateId,
+        track: params.track,
+        gradeId: params.gradeId,
+        gradeLabel: params.gradeLabel,
+        seatId: params.seatId,
+        quantity: params.quantity,
+        unitPrice: params.unitPrice,
+        totalPrice: params.unitPrice * params.quantity,
+        status: 'pending',
+        createdAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + timeoutMinutes * 60 * 1000).toISOString(),
+      }
+      mockTickets.push(reservation)
+      return reservation
+    }
+    return (await client.post<Reservation>('/reservations', params)).data
+  },
+
+  async getById(id: string): Promise<Reservation | undefined> {
+    if (USE_MOCK) return mockTickets.find((r) => r.id === id)
+    return (await client.get<Reservation>(`/reservations/${id}`)).data
+  },
+
+  async getMyTickets(): Promise<Reservation[]> {
+    if (USE_MOCK) return [...mockTickets].reverse()
+    return (await client.get<Reservation[]>('/reservations/my')).data
+  },
+
+  async pay(reservationId: string): Promise<Reservation> {
+    if (USE_MOCK) {
+      const r = mockTickets.find((t) => t.id === reservationId)
+      if (r) r.status = 'paid'
+      return r!
+    }
+    return (await client.post<Reservation>(`/reservations/${reservationId}/pay`)).data
+  },
+}

--- a/src/api/seat.api.ts
+++ b/src/api/seat.api.ts
@@ -1,0 +1,23 @@
+import type { SeatSection, SeatHoldResponse } from '@/types/seat'
+import client from './client'
+import { getMockSeatSections } from './mock/seats.mock'
+
+const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true'
+
+export const seatApi = {
+  async getSeatMap(_concertId: string, _dateId: string): Promise<SeatSection[]> {
+    if (USE_MOCK) return getMockSeatSections()
+    return (await client.get<SeatSection[]>(`/seats/${_concertId}/${_dateId}`)).data
+  },
+
+  async holdSeat(concertId: string, dateId: string, seatId: string, token: string): Promise<SeatHoldResponse> {
+    if (USE_MOCK) {
+      return {
+        holdId: `hold-${Date.now()}`,
+        expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+        seatId,
+      }
+    }
+    return (await client.post<SeatHoldResponse>('/seats/hold', { concertId, dateId, seatId, token })).data
+  },
+}

--- a/src/components/seat/SeatMap.vue
+++ b/src/components/seat/SeatMap.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import type { Seat, SeatSection } from '@/types/seat'
+
+defineProps<{
+  sections: SeatSection[]
+  selectedSeatId: string | null
+}>()
+
+const emit = defineEmits<{
+  select: [seat: Seat]
+}>()
+
+const gradeColors: Record<string, { fill: string; stroke: string }> = {
+  vip: { fill: '#7C3AED', stroke: '#6D28D9' },
+  r: { fill: '#2563EB', stroke: '#1D4ED8' },
+  s: { fill: '#059669', stroke: '#047857' },
+  a: { fill: '#D97706', stroke: '#B45309' },
+}
+
+function seatColor(seat: Seat, isSelected: boolean) {
+  if (isSelected) return { fill: '#EC4899', stroke: '#DB2777' }
+  if (seat.status === 'sold') return { fill: '#27272A', stroke: '#3F3F46' }
+  if (seat.status === 'held') return { fill: '#52525B', stroke: '#71717A' }
+  return gradeColors[seat.gradeId] ?? { fill: '#6B7280', stroke: '#4B5563' }
+}
+</script>
+
+<template>
+  <div class="w-full overflow-x-auto">
+    <svg
+      viewBox="0 0 700 560"
+      class="w-full min-w-[500px] h-auto"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <!-- 스테이지 -->
+      <rect x="200" y="20" width="300" height="40" rx="20" fill="hsl(265,85%,60%)" opacity="0.3" />
+      <text x="350" y="46" text-anchor="middle" fill="white" font-size="14" font-weight="600">STAGE</text>
+
+      <!-- 좌석 -->
+      <template v-for="section in sections" :key="section.id">
+        <g v-for="seat in section.seats" :key="seat.id">
+          <rect
+            :x="seat.x"
+            :y="seat.y"
+            width="22"
+            height="22"
+            rx="4"
+            :fill="seatColor(seat, selectedSeatId === seat.id).fill"
+            :stroke="seatColor(seat, selectedSeatId === seat.id).stroke"
+            stroke-width="1.5"
+            :class="[
+              seat.status === 'available' ? 'cursor-pointer hover:opacity-80' : 'cursor-not-allowed',
+              selectedSeatId === seat.id ? 'animate-pulse' : '',
+            ]"
+            @click="seat.status === 'available' && emit('select', seat)"
+          />
+          <text
+            v-if="selectedSeatId === seat.id"
+            :x="seat.x + 11"
+            :y="seat.y + 15"
+            text-anchor="middle"
+            fill="white"
+            font-size="10"
+            font-weight="700"
+          >
+            ✓
+          </text>
+        </g>
+      </template>
+    </svg>
+  </div>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -30,6 +30,40 @@ const router = createRouter({
       component: () => import('@/views/QueuePage.vue'),
       meta: { requiresAuth: true },
     },
+    {
+      path: '/cart/:concertId',
+      name: 'cart',
+      component: () => import('@/views/CartPage.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/seats/:concertId',
+      name: 'seats',
+      component: () => import('@/views/SeatsPage.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/payment/result',
+      name: 'payment-result',
+      component: () => import('@/views/PaymentResultPage.vue'),
+    },
+    {
+      path: '/payment/:reservationId',
+      name: 'payment',
+      component: () => import('@/views/PaymentPage.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/my/tickets',
+      name: 'my-tickets',
+      component: () => import('@/views/MyTicketsPage.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/:pathMatch(.*)*',
+      name: 'not-found',
+      component: () => import('@/views/NotFoundPage.vue'),
+    },
   ],
 })
 

--- a/src/views/CartPage.vue
+++ b/src/views/CartPage.vue
@@ -1,0 +1,234 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ShoppingCart, Minus, Plus, Info, Loader2, ArrowRight } from 'lucide-vue-next'
+import type { Concert, TicketGrade } from '@/types/concert'
+import { concertApi } from '@/api/concert.api'
+import { reservationApi } from '@/api/reservation.api'
+import { usePaymentStore } from '@/stores/payment.store'
+
+const route = useRoute()
+const router = useRouter()
+const paymentStore = usePaymentStore()
+
+const concertId = route.params.concertId as string
+const concert = ref<Concert | null>(null)
+const loading = ref(true)
+const submitting = ref(false)
+
+const selectedGrade = ref<TicketGrade | null>(null)
+const quantity = ref(1)
+
+onMounted(async () => {
+  try {
+    concert.value = (await concertApi.getById(concertId)) ?? null
+  } finally {
+    loading.value = false
+  }
+})
+
+const totalPrice = computed(() => {
+  if (!selectedGrade.value) return 0
+  return selectedGrade.value.price * quantity.value
+})
+
+const selectedDate = computed(() => concert.value?.dates.find((d) => d.available))
+
+function selectGrade(grade: TicketGrade) {
+  selectedGrade.value = grade
+}
+
+async function handleSubmit() {
+  if (!concert.value || !selectedGrade.value || !selectedDate.value) return
+  submitting.value = true
+  try {
+    const reservation = await reservationApi.create({
+      concertId: concert.value.id,
+      concertTitle: concert.value.title,
+      dateId: selectedDate.value.id,
+      track: 'cart',
+      gradeId: selectedGrade.value.id,
+      gradeLabel: selectedGrade.value.label,
+      unitPrice: selectedGrade.value.price,
+      quantity: quantity.value,
+    })
+    paymentStore.setReservation(reservation)
+    router.push(`/payment/${reservation.id}`)
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div v-if="loading" class="flex items-center justify-center min-h-[60vh]">
+    <Loader2 class="w-8 h-8 animate-spin text-primary" />
+  </div>
+
+  <div v-else-if="!concert" class="flex flex-col items-center justify-center min-h-[60vh]">
+    <h2 class="font-display text-2xl font-bold text-foreground mb-2">공연을 찾을 수 없습니다</h2>
+    <RouterLink to="/" class="text-primary hover:underline">홈으로 돌아가기</RouterLink>
+  </div>
+
+  <div v-else class="px-4 lg:px-8 mx-auto max-w-7xl py-8 md:py-12">
+    <!-- 헤더 -->
+    <div class="flex items-center gap-3 mb-8">
+      <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
+        <ShoppingCart class="w-5 h-5 text-primary" />
+      </div>
+      <div>
+        <h1 class="font-display text-2xl font-bold text-foreground">장바구니 예매</h1>
+        <p class="text-sm text-muted-foreground">{{ concert.title }}</p>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+      <!-- 좌측: 등급 + 수량 선택 -->
+      <div class="lg:col-span-2 space-y-8">
+        <!-- 안내 -->
+        <div class="flex items-start gap-3 p-4 rounded-xl bg-primary/5 border border-primary/20">
+          <Info class="w-5 h-5 text-primary mt-0.5 shrink-0" />
+          <div class="text-sm text-muted-foreground leading-relaxed">
+            <p class="font-medium text-foreground mb-1">장바구니 예매 안내</p>
+            등급과 수량만 선택하면 좌석은 결제 완료 후 <strong class="text-foreground">랜덤 배정</strong>됩니다.
+            최대 2매까지 예매 가능합니다.
+          </div>
+        </div>
+
+        <!-- 등급 선택 -->
+        <section>
+          <h2 class="font-display text-lg font-bold text-foreground mb-4">등급 선택</h2>
+          <div class="space-y-3">
+            <button
+              v-for="grade in concert.grades"
+              :key="grade.id"
+              :disabled="grade.availableSeats <= 0"
+              :class="[
+                'w-full flex items-center justify-between p-4 rounded-xl border text-left transition-all',
+                selectedGrade?.id === grade.id
+                  ? 'border-primary bg-primary/10 ring-1 ring-primary'
+                  : grade.availableSeats > 0
+                    ? 'border-border bg-card hover:border-muted-foreground/30'
+                    : 'border-border bg-card opacity-50 cursor-not-allowed',
+              ]"
+              @click="selectGrade(grade)"
+            >
+              <div class="flex items-center gap-4">
+                <span
+                  class="w-12 h-12 rounded-lg bg-primary/10 text-primary font-display font-bold text-base flex items-center justify-center"
+                >
+                  {{ grade.label }}
+                </span>
+                <div>
+                  <div class="flex items-baseline gap-2">
+                    <span class="font-display text-lg font-bold text-foreground">
+                      ₩{{ grade.price.toLocaleString() }}
+                    </span>
+                    <span v-if="grade.originalPrice" class="text-sm text-muted-foreground line-through">
+                      ₩{{ grade.originalPrice.toLocaleString() }}
+                    </span>
+                  </div>
+                  <p class="text-xs text-muted-foreground mt-0.5">
+                    잔여 {{ grade.availableSeats }}석
+                  </p>
+                </div>
+              </div>
+              <div
+                v-if="selectedGrade?.id === grade.id"
+                class="w-6 h-6 rounded-full bg-primary flex items-center justify-center"
+              >
+                <svg class="w-3.5 h-3.5 text-primary-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              </div>
+            </button>
+          </div>
+        </section>
+
+        <!-- 수량 선택 -->
+        <section v-if="selectedGrade">
+          <h2 class="font-display text-lg font-bold text-foreground mb-4">수량 선택</h2>
+          <div class="flex items-center gap-4 p-4 rounded-xl border border-border bg-card">
+            <button
+              :disabled="quantity <= 1"
+              class="w-10 h-10 rounded-lg border border-border bg-secondary text-foreground flex items-center justify-center hover:bg-muted transition-colors disabled:opacity-30"
+              @click="quantity = Math.max(1, quantity - 1)"
+            >
+              <Minus class="w-4 h-4" />
+            </button>
+            <span class="font-display text-2xl font-bold text-foreground w-8 text-center">
+              {{ quantity }}
+            </span>
+            <button
+              :disabled="quantity >= 2"
+              class="w-10 h-10 rounded-lg border border-border bg-secondary text-foreground flex items-center justify-center hover:bg-muted transition-colors disabled:opacity-30"
+              @click="quantity = Math.min(2, quantity + 1)"
+            >
+              <Plus class="w-4 h-4" />
+            </button>
+            <span class="text-sm text-muted-foreground">최대 2매</span>
+          </div>
+        </section>
+      </div>
+
+      <!-- 우측: 주문 요약 -->
+      <div class="lg:col-span-1">
+        <div class="sticky top-24 rounded-xl border border-border bg-card p-6">
+          <h3 class="font-display text-lg font-bold text-foreground mb-4">주문 요약</h3>
+
+          <div v-if="!selectedGrade" class="flex items-center gap-2 text-muted-foreground py-8 justify-center">
+            <Info class="w-4 h-4" />
+            <span class="text-sm">등급을 선택해주세요</span>
+          </div>
+
+          <template v-else>
+            <div class="space-y-3 mb-4">
+              <div>
+                <p class="text-xs text-muted-foreground uppercase tracking-wider mb-1">공연</p>
+                <p class="text-sm font-medium text-foreground">{{ concert.title }}</p>
+              </div>
+              <div v-if="selectedDate">
+                <p class="text-xs text-muted-foreground uppercase tracking-wider mb-1">일정</p>
+                <p class="text-sm text-foreground">{{ selectedDate.venue }}, {{ selectedDate.city }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-muted-foreground uppercase tracking-wider mb-1">등급</p>
+                <p class="text-sm text-foreground">{{ selectedGrade.label }} × {{ quantity }}매</p>
+              </div>
+            </div>
+
+            <div class="h-px bg-border my-4" />
+
+            <div class="flex items-center justify-between mb-2">
+              <span class="text-sm text-muted-foreground">{{ selectedGrade.label }} × {{ quantity }}</span>
+              <span class="text-sm text-foreground">₩{{ totalPrice.toLocaleString() }}</span>
+            </div>
+
+            <div class="h-px bg-border my-4" />
+
+            <div class="flex items-center justify-between mb-6">
+              <span class="font-display font-bold text-foreground">합계</span>
+              <span class="font-display text-xl font-bold text-foreground">₩{{ totalPrice.toLocaleString() }}</span>
+            </div>
+
+            <button
+              :disabled="submitting"
+              class="w-full h-12 rounded-full bg-primary text-primary-foreground font-semibold text-base hover:bg-primary/90 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
+              @click="handleSubmit"
+            >
+              <Loader2 v-if="submitting" class="w-4 h-4 animate-spin" />
+              <template v-else>
+                결제하기
+                <ArrowRight class="w-4 h-4" />
+              </template>
+            </button>
+
+            <p class="text-xs text-muted-foreground text-center mt-3">
+              좌석은 결제 완료 후 랜덤 배정됩니다.
+            </p>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/views/MyTicketsPage.vue
+++ b/src/views/MyTicketsPage.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { Ticket, Loader2, Calendar, Tag } from 'lucide-vue-next'
+import type { Reservation } from '@/types/reservation'
+import { reservationApi } from '@/api/reservation.api'
+
+const tickets = ref<Reservation[]>([])
+const loading = ref(true)
+
+onMounted(async () => {
+  try {
+    tickets.value = await reservationApi.getMyTickets()
+  } finally {
+    loading.value = false
+  }
+})
+
+function statusBadge(status: Reservation['status']) {
+  switch (status) {
+    case 'paid':
+      return { text: '결제완료', class: 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30' }
+    case 'pending':
+      return { text: '결제대기', class: 'bg-amber-500/20 text-amber-400 border-amber-500/30' }
+    case 'cancelled':
+      return { text: '취소됨', class: 'bg-destructive/20 text-destructive border-destructive/30' }
+    case 'expired':
+      return { text: '만료됨', class: 'bg-muted text-muted-foreground border-border' }
+  }
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+</script>
+
+<template>
+  <div class="px-4 lg:px-8 mx-auto max-w-4xl py-8 md:py-12">
+    <div class="flex items-center gap-3 mb-8">
+      <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
+        <Ticket class="w-5 h-5 text-primary" />
+      </div>
+      <h1 class="font-display text-2xl font-bold text-foreground">마이 티켓</h1>
+    </div>
+
+    <div v-if="loading" class="flex items-center justify-center py-20">
+      <Loader2 class="w-8 h-8 animate-spin text-primary" />
+    </div>
+
+    <div v-else-if="tickets.length === 0" class="text-center py-20">
+      <Ticket class="w-12 h-12 text-muted-foreground mx-auto mb-4 opacity-50" />
+      <p class="text-muted-foreground mb-4">예매 내역이 없습니다.</p>
+      <RouterLink
+        to="/"
+        class="inline-flex items-center justify-center h-10 px-5 rounded-full bg-primary text-primary-foreground font-semibold text-sm hover:bg-primary/90 transition-colors"
+      >
+        공연 둘러보기
+      </RouterLink>
+    </div>
+
+    <div v-else class="space-y-4">
+      <div
+        v-for="ticket in tickets"
+        :key="ticket.id"
+        class="rounded-xl border border-border bg-card p-5 md:p-6 transition-all hover:border-muted-foreground/20"
+      >
+        <div class="flex flex-col sm:flex-row sm:items-start justify-between gap-4">
+          <!-- 좌측 정보 -->
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 mb-2">
+              <h3 class="font-display font-bold text-foreground text-base truncate">
+                {{ ticket.concertTitle }}
+              </h3>
+              <span
+                :class="statusBadge(ticket.status).class"
+                class="px-2 py-0.5 text-xs font-semibold rounded-full border shrink-0"
+              >
+                {{ statusBadge(ticket.status).text }}
+              </span>
+            </div>
+
+            <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+              <div class="flex items-center gap-1.5">
+                <Tag class="w-3.5 h-3.5" />
+                {{ ticket.gradeLabel }} × {{ ticket.quantity }}매
+                <span v-if="ticket.track === 'cart'" class="text-xs">(장바구니)</span>
+                <span v-else class="text-xs">(당일)</span>
+              </div>
+              <div class="flex items-center gap-1.5">
+                <Calendar class="w-3.5 h-3.5" />
+                {{ formatDate(ticket.createdAt) }}
+              </div>
+            </div>
+
+            <p v-if="ticket.seatId" class="text-xs text-muted-foreground mt-1">
+              좌석: {{ ticket.seatId }}
+            </p>
+            <p class="text-xs text-muted-foreground mt-1 font-mono">
+              예매번호: {{ ticket.id }}
+            </p>
+          </div>
+
+          <!-- 우측 금액 -->
+          <div class="text-right shrink-0">
+            <p class="font-display text-lg font-bold text-foreground">
+              ₩{{ ticket.totalPrice.toLocaleString() }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/views/NotFoundPage.vue
+++ b/src/views/NotFoundPage.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <div class="min-h-[calc(100vh-4rem)] flex flex-col items-center justify-center px-4">
+    <p class="font-display text-7xl font-bold text-primary mb-4">404</p>
+    <h1 class="font-display text-2xl font-bold text-foreground mb-2">페이지를 찾을 수 없습니다</h1>
+    <p class="text-muted-foreground mb-8">요청하신 페이지가 존재하지 않거나 이동되었습니다.</p>
+    <RouterLink
+      to="/"
+      class="inline-flex items-center justify-center h-11 px-6 rounded-full bg-primary text-primary-foreground font-semibold text-sm hover:bg-primary/90 transition-colors"
+    >
+      홈으로 돌아가기
+    </RouterLink>
+  </div>
+</template>

--- a/src/views/PaymentPage.vue
+++ b/src/views/PaymentPage.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { CreditCard, Clock, Loader2, ShieldCheck } from 'lucide-vue-next'
+import { usePaymentStore } from '@/stores/payment.store'
+import { reservationApi } from '@/api/reservation.api'
+import { useCountdown } from '@/composables/useCountdown'
+
+const route = useRoute()
+const router = useRouter()
+const paymentStore = usePaymentStore()
+
+const reservationId = route.params.reservationId as string
+const loading = ref(true)
+const paying = ref(false)
+const selectedMethod = ref<'card' | 'kakao' | 'toss'>('card')
+
+onMounted(async () => {
+  try {
+    if (!paymentStore.reservation || paymentStore.reservation.id !== reservationId) {
+      const r = await reservationApi.getById(reservationId)
+      if (r) paymentStore.setReservation(r)
+      else {
+        router.push('/')
+        return
+      }
+    }
+  } finally {
+    loading.value = false
+  }
+})
+
+const countdown = useCountdown(paymentStore.reservation?.expiresAt ?? null)
+onMounted(() => {
+  if (paymentStore.reservation) countdown.start()
+})
+
+watch(countdown.isExpired, (expired) => {
+  if (expired) router.push('/payment/result?status=expired')
+})
+
+const methods = [
+  { id: 'card' as const, label: '신용/체크카드', icon: CreditCard },
+  { id: 'kakao' as const, label: '카카오페이', icon: ShieldCheck },
+  { id: 'toss' as const, label: '토스페이', icon: ShieldCheck },
+]
+
+async function handlePay() {
+  if (!paymentStore.reservation) return
+  paying.value = true
+  paymentStore.setStatus('processing')
+  try {
+    // PoC — 목 결제 (1.5초 딜레이)
+    await new Promise((r) => setTimeout(r, 1500))
+    await reservationApi.pay(paymentStore.reservation!.id)
+    paymentStore.setStatus('success')
+    router.push('/payment/result?status=success')
+  } catch {
+    paymentStore.setStatus('fail', '결제에 실패했습니다.')
+    router.push('/payment/result?status=fail')
+  }
+}
+</script>
+
+<template>
+  <div v-if="loading" class="flex items-center justify-center min-h-[60vh]">
+    <Loader2 class="w-8 h-8 animate-spin text-primary" />
+  </div>
+
+  <div v-else-if="paymentStore.reservation" class="px-4 lg:px-8 mx-auto max-w-7xl py-8 md:py-12">
+    <!-- 타이머 -->
+    <div class="flex items-center justify-center gap-2 mb-8 px-4 py-3 rounded-full border border-border bg-card w-fit mx-auto">
+      <Clock class="w-4 h-4 text-primary" />
+      <span class="text-sm text-muted-foreground">결제 제한 시간</span>
+      <span
+        class="font-display font-bold text-lg"
+        :class="countdown.remaining.value < 60 ? 'text-destructive' : 'text-foreground'"
+      >
+        {{ countdown.display.value }}
+      </span>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+      <!-- 좌측: 결제 수단 -->
+      <div class="lg:col-span-2 space-y-6">
+        <section>
+          <h2 class="font-display text-xl font-bold text-foreground mb-4">결제 수단 선택</h2>
+          <div class="space-y-3">
+            <button
+              v-for="method in methods"
+              :key="method.id"
+              :class="[
+                'w-full flex items-center gap-4 p-4 rounded-xl border text-left transition-all',
+                selectedMethod === method.id
+                  ? 'border-primary bg-primary/10 ring-1 ring-primary'
+                  : 'border-border bg-card hover:border-muted-foreground/30',
+              ]"
+              @click="selectedMethod = method.id"
+            >
+              <div class="w-10 h-10 rounded-lg bg-secondary flex items-center justify-center">
+                <component :is="method.icon" class="w-5 h-5 text-foreground" />
+              </div>
+              <span class="text-sm font-medium text-foreground">{{ method.label }}</span>
+              <div
+                v-if="selectedMethod === method.id"
+                class="ml-auto w-5 h-5 rounded-full bg-primary flex items-center justify-center"
+              >
+                <svg class="w-3 h-3 text-primary-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              </div>
+            </button>
+          </div>
+        </section>
+
+        <!-- 결제 처리 중 오버레이 -->
+        <div
+          v-if="paying"
+          class="flex flex-col items-center justify-center py-16"
+        >
+          <Loader2 class="w-12 h-12 animate-spin text-primary mb-4" />
+          <p class="font-display text-lg font-bold text-foreground">결제 처리 중...</p>
+          <p class="text-sm text-muted-foreground mt-1">잠시만 기다려주세요</p>
+        </div>
+      </div>
+
+      <!-- 우측: 주문 요약 -->
+      <div class="lg:col-span-1">
+        <div class="sticky top-24 rounded-xl border border-border bg-card p-6">
+          <h3 class="font-display text-lg font-bold text-foreground mb-4">주문 요약</h3>
+
+          <div class="space-y-3 mb-4">
+            <div>
+              <p class="text-xs text-muted-foreground uppercase tracking-wider mb-1">공연</p>
+              <p class="text-sm font-medium text-foreground">{{ paymentStore.reservation.concertTitle }}</p>
+            </div>
+            <div>
+              <p class="text-xs text-muted-foreground uppercase tracking-wider mb-1">트랙</p>
+              <p class="text-sm text-foreground">
+                {{ paymentStore.reservation.track === 'cart' ? '장바구니 예매' : '당일 예매' }}
+              </p>
+            </div>
+            <div>
+              <p class="text-xs text-muted-foreground uppercase tracking-wider mb-1">등급 / 수량</p>
+              <p class="text-sm text-foreground">
+                {{ paymentStore.reservation.gradeLabel }} × {{ paymentStore.reservation.quantity }}매
+              </p>
+            </div>
+            <div v-if="paymentStore.reservation.seatId">
+              <p class="text-xs text-muted-foreground uppercase tracking-wider mb-1">좌석</p>
+              <p class="text-sm text-foreground">{{ paymentStore.reservation.seatId }}</p>
+            </div>
+          </div>
+
+          <div class="h-px bg-border my-4" />
+
+          <div class="flex items-center justify-between mb-6">
+            <span class="font-display font-bold text-foreground">합계</span>
+            <span class="font-display text-xl font-bold text-foreground">
+              ₩{{ paymentStore.reservation.totalPrice.toLocaleString() }}
+            </span>
+          </div>
+
+          <button
+            :disabled="paying"
+            class="w-full h-12 rounded-full bg-primary text-primary-foreground font-semibold text-base hover:bg-primary/90 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
+            @click="handlePay"
+          >
+            <Loader2 v-if="paying" class="w-4 h-4 animate-spin" />
+            {{ paying ? '결제 중...' : `₩${paymentStore.reservation.totalPrice.toLocaleString()} 결제하기` }}
+          </button>
+
+          <p class="text-xs text-muted-foreground text-center mt-3">
+            결제 시 이용약관에 동의하는 것으로 간주합니다.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/views/PaymentResultPage.vue
+++ b/src/views/PaymentResultPage.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { CheckCircle, XCircle, Clock, ArrowRight } from 'lucide-vue-next'
+import { usePaymentStore } from '@/stores/payment.store'
+
+const route = useRoute()
+const paymentStore = usePaymentStore()
+
+const status = computed(() => (route.query.status as string) || 'fail')
+
+const isSuccess = computed(() => status.value === 'success')
+const isExpired = computed(() => status.value === 'expired')
+</script>
+
+<template>
+  <div class="min-h-[calc(100vh-4rem)] flex items-center justify-center px-4 py-12">
+    <div class="w-full max-w-md text-center">
+      <!-- 성공 -->
+      <template v-if="isSuccess">
+        <div class="w-20 h-20 rounded-full bg-emerald-500/20 flex items-center justify-center mx-auto mb-6">
+          <CheckCircle class="w-10 h-10 text-emerald-400" />
+        </div>
+        <h1 class="font-display text-2xl font-bold text-foreground mb-2">결제 완료!</h1>
+        <p class="text-muted-foreground mb-8">티켓이 성공적으로 예매되었습니다.</p>
+
+        <div v-if="paymentStore.reservation" class="rounded-xl border border-border bg-card p-6 text-left mb-8">
+          <div class="space-y-3">
+            <div>
+              <p class="text-xs text-muted-foreground uppercase tracking-wider mb-1">공연</p>
+              <p class="text-sm font-medium text-foreground">{{ paymentStore.reservation.concertTitle }}</p>
+            </div>
+            <div>
+              <p class="text-xs text-muted-foreground uppercase tracking-wider mb-1">예매 번호</p>
+              <p class="text-sm font-mono text-primary">{{ paymentStore.reservation.id }}</p>
+            </div>
+            <div class="flex justify-between">
+              <div>
+                <p class="text-xs text-muted-foreground uppercase tracking-wider mb-1">등급</p>
+                <p class="text-sm text-foreground">{{ paymentStore.reservation.gradeLabel }}</p>
+              </div>
+              <div class="text-right">
+                <p class="text-xs text-muted-foreground uppercase tracking-wider mb-1">결제 금액</p>
+                <p class="text-sm font-bold text-foreground">₩{{ paymentStore.reservation.totalPrice.toLocaleString() }}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+          <RouterLink
+            to="/my/tickets"
+            class="inline-flex items-center justify-center h-11 px-6 rounded-full bg-primary text-primary-foreground font-semibold text-sm hover:bg-primary/90 transition-colors gap-2"
+          >
+            마이 티켓 보기
+            <ArrowRight class="w-4 h-4" />
+          </RouterLink>
+          <RouterLink
+            to="/"
+            class="inline-flex items-center justify-center h-11 px-6 rounded-full border border-border text-foreground font-semibold text-sm hover:bg-secondary transition-colors"
+          >
+            홈으로
+          </RouterLink>
+        </div>
+      </template>
+
+      <!-- 만료 -->
+      <template v-else-if="isExpired">
+        <div class="w-20 h-20 rounded-full bg-amber-500/20 flex items-center justify-center mx-auto mb-6">
+          <Clock class="w-10 h-10 text-amber-400" />
+        </div>
+        <h1 class="font-display text-2xl font-bold text-foreground mb-2">결제 시간 만료</h1>
+        <p class="text-muted-foreground mb-8">결제 제한 시간이 초과되었습니다.<br />다시 예매해주세요.</p>
+        <RouterLink
+          to="/"
+          class="inline-flex items-center justify-center h-11 px-6 rounded-full bg-primary text-primary-foreground font-semibold text-sm hover:bg-primary/90 transition-colors gap-2"
+        >
+          홈으로 돌아가기
+          <ArrowRight class="w-4 h-4" />
+        </RouterLink>
+      </template>
+
+      <!-- 실패 -->
+      <template v-else>
+        <div class="w-20 h-20 rounded-full bg-destructive/20 flex items-center justify-center mx-auto mb-6">
+          <XCircle class="w-10 h-10 text-destructive" />
+        </div>
+        <h1 class="font-display text-2xl font-bold text-foreground mb-2">결제 실패</h1>
+        <p class="text-muted-foreground mb-8">
+          {{ paymentStore.failReason || '결제 처리 중 오류가 발생했습니다.' }}
+        </p>
+        <RouterLink
+          to="/"
+          class="inline-flex items-center justify-center h-11 px-6 rounded-full bg-primary text-primary-foreground font-semibold text-sm hover:bg-primary/90 transition-colors gap-2"
+        >
+          홈으로 돌아가기
+          <ArrowRight class="w-4 h-4" />
+        </RouterLink>
+      </template>
+    </div>
+  </div>
+</template>

--- a/src/views/SeatsPage.vue
+++ b/src/views/SeatsPage.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { Clock, Loader2, ArrowRight } from 'lucide-vue-next'
+import type { Concert } from '@/types/concert'
+import type { Seat, SeatSection } from '@/types/seat'
+import { concertApi } from '@/api/concert.api'
+import { seatApi } from '@/api/seat.api'
+import { reservationApi } from '@/api/reservation.api'
+import { usePaymentStore } from '@/stores/payment.store'
+import { useQueueStore } from '@/stores/queue.store'
+import { useCountdown } from '@/composables/useCountdown'
+import SeatMap from '@/components/seat/SeatMap.vue'
+
+const route = useRoute()
+const router = useRouter()
+const paymentStore = usePaymentStore()
+const queueStore = useQueueStore()
+
+const concertId = route.params.concertId as string
+const concert = ref<Concert | null>(null)
+const sections = ref<SeatSection[]>([])
+const selectedSeat = ref<Seat | null>(null)
+const loading = ref(true)
+const submitting = ref(false)
+
+// 10분 홀드 타이머
+const holdExpiry = ref<string>(new Date(Date.now() + 10 * 60 * 1000).toISOString())
+const countdown = useCountdown(holdExpiry.value)
+
+onMounted(async () => {
+  try {
+    concert.value = (await concertApi.getById(concertId)) ?? null
+    const dateId = concert.value?.dates.find((d) => d.available)?.id ?? ''
+    sections.value = await seatApi.getSeatMap(concertId, dateId)
+    countdown.start()
+  } finally {
+    loading.value = false
+  }
+})
+
+// 타이머 만료 시 돌려보냄
+watch(countdown.isExpired, (expired) => {
+  if (expired) router.push(`/concerts/${concertId}`)
+})
+
+const selectedDate = computed(() => concert.value?.dates.find((d) => d.available))
+const selectedGrade = computed(() => {
+  if (!selectedSeat.value || !concert.value) return null
+  return concert.value.grades.find((g) => g.id === selectedSeat.value!.gradeId)
+})
+
+function handleSelect(seat: Seat) {
+  selectedSeat.value = selectedSeat.value?.id === seat.id ? null : seat
+}
+
+async function handleSubmit() {
+  if (!concert.value || !selectedSeat.value || !selectedGrade.value || !selectedDate.value) return
+  submitting.value = true
+  try {
+    const reservation = await reservationApi.create({
+      concertId: concert.value.id,
+      concertTitle: concert.value.title,
+      dateId: selectedDate.value.id,
+      track: 'realtime',
+      gradeId: selectedGrade.value.id,
+      gradeLabel: selectedGrade.value.label,
+      unitPrice: selectedGrade.value.price,
+      quantity: 1,
+      seatId: selectedSeat.value.id,
+    })
+    paymentStore.setReservation(reservation)
+    queueStore.reset()
+    router.push(`/payment/${reservation.id}`)
+  } finally {
+    submitting.value = false
+  }
+}
+
+const legendItems = [
+  { label: 'VIP', color: '#7C3AED' },
+  { label: 'R석', color: '#2563EB' },
+  { label: 'S석', color: '#059669' },
+  { label: 'A석', color: '#D97706' },
+  { label: '선택', color: '#EC4899' },
+  { label: '홀드', color: '#52525B' },
+  { label: '매진', color: '#27272A' },
+]
+</script>
+
+<template>
+  <div v-if="loading" class="flex items-center justify-center min-h-[60vh]">
+    <Loader2 class="w-8 h-8 animate-spin text-primary" />
+  </div>
+
+  <div v-else class="px-4 lg:px-8 mx-auto max-w-7xl py-8">
+    <!-- 헤더 + 타이머 -->
+    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
+      <div>
+        <h1 class="font-display text-2xl font-bold text-foreground">좌석 선택</h1>
+        <p class="text-sm text-muted-foreground">{{ concert?.title }}</p>
+      </div>
+      <div class="flex items-center gap-2 px-4 py-2 rounded-full border border-border bg-card">
+        <Clock class="w-4 h-4 text-primary" />
+        <span class="font-display font-bold text-foreground" :class="countdown.remaining.value < 60 ? 'text-destructive' : ''">
+          {{ countdown.display.value }}
+        </span>
+        <span class="text-xs text-muted-foreground">남음</span>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-4 gap-8">
+      <!-- 좌석맵 -->
+      <div class="lg:col-span-3">
+        <div class="rounded-xl border border-border bg-card p-4 md:p-6">
+          <!-- 범례 -->
+          <div class="flex flex-wrap gap-3 mb-4">
+            <div v-for="item in legendItems" :key="item.label" class="flex items-center gap-1.5">
+              <span class="w-4 h-4 rounded" :style="{ backgroundColor: item.color }" />
+              <span class="text-xs text-muted-foreground">{{ item.label }}</span>
+            </div>
+          </div>
+
+          <SeatMap
+            :sections="sections"
+            :selected-seat-id="selectedSeat?.id ?? null"
+            @select="handleSelect"
+          />
+        </div>
+      </div>
+
+      <!-- 사이드바 -->
+      <div class="lg:col-span-1">
+        <div class="sticky top-24 rounded-xl border border-border bg-card p-6">
+          <h3 class="font-display text-lg font-bold text-foreground mb-4">선택 좌석</h3>
+
+          <div v-if="!selectedSeat" class="text-center py-8 text-sm text-muted-foreground">
+            좌석을 클릭해 선택하세요
+          </div>
+
+          <template v-else>
+            <div class="space-y-3 mb-4">
+              <div>
+                <p class="text-xs text-muted-foreground uppercase tracking-wider mb-1">좌석</p>
+                <p class="text-sm font-medium text-foreground">
+                  {{ selectedSeat.section.toUpperCase() }}구역
+                  {{ selectedSeat.row }}열 {{ selectedSeat.number }}번
+                </p>
+              </div>
+              <div v-if="selectedGrade">
+                <p class="text-xs text-muted-foreground uppercase tracking-wider mb-1">등급</p>
+                <p class="text-sm text-foreground">{{ selectedGrade.label }}</p>
+              </div>
+            </div>
+
+            <div class="h-px bg-border my-4" />
+
+            <div class="flex items-center justify-between mb-6">
+              <span class="font-display font-bold text-foreground">합계</span>
+              <span class="font-display text-xl font-bold text-foreground">
+                ₩{{ selectedGrade?.price.toLocaleString() }}
+              </span>
+            </div>
+
+            <button
+              :disabled="submitting"
+              class="w-full h-12 rounded-full bg-primary text-primary-foreground font-semibold text-base hover:bg-primary/90 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
+              @click="handleSubmit"
+            >
+              <Loader2 v-if="submitting" class="w-4 h-4 animate-spin" />
+              <template v-else>
+                결제하기
+                <ArrowRight class="w-4 h-4" />
+              </template>
+            </button>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
  - Phase 1 1차(#3) 이어서 나머지 5개 화면 + 404 페이지 구현
  - 전체 10개 화면 완성, mock 데이터 기반 풀 플로우 동작

  ## 구현 범위

  ### 신규 페이지 (6개)
  | 경로 | 설명 |
  |---|---|
  | `/cart/:concertId` | 장바구니 예매 (등급·수량 선택, 최대 2매, 랜덤 배정
  안내) |
  | `/seats/:concertId` | 좌석 선택 (SVG 좌석맵, 등급별 색상, 10분 홀드 타이머)
  |
  | `/payment/:reservationId` | 결제 (카드/카카오/토스 선택, 카운트다운, 목
  결제) |
  | `/payment/result` | 결제 결과 (성공/실패/만료 분기) |
  | `/my/tickets` | 마이 티켓 (예매 내역 + 상태 뱃지) |
  | `/:pathMatch(.*)*` | 404 페이지 |

  ### 신규 인프라
  - `api/seat.api.ts` — 좌석맵 조회 + 홀드 API
  - `api/reservation.api.ts` — 예매 생성/조회/결제 API
  - `api/mock/seats.mock.ts` — SVG 좌석 목 데이터 생성기
  - `components/seat/SeatMap.vue` — SVG 좌석맵 컴포넌트

  ### 전체 플로우
  로그인 → 목록 → 상세 → 장바구니 → 결제 → 결과 → 마이 티켓
                       → 당일 → 대기열 → 좌석 선택 → 결제 → 결과

  ## Screenshots
<img width="1735" height="832" alt="스크린샷 2026-02-10 오후 1 34 51" src="https://github.com/user-attachments/assets/db7eacf6-eb2f-4e29-bf3a-80a62a62ac36" />
<img width="1735" height="841" alt="스크린샷 2026-02-10 오후 1 33 44" src="https://github.com/user-attachments/assets/7f18fd65-6c14-4fb2-92e7-a07216e2ab55" />
<img width="1739" height="857" alt="스크린샷 2026-02-10 오후 1 33 36" src="https://github.com/user-attachments/assets/42546eba-bf21-4cc1-9b83-67e1d6734969" />


  ## Test Plan
  - [ ] `pnpm dev`로 로컬 실행
  - [ ] 장바구니 트랙: 상세 → 장바구니 → 등급/수량 선택 → 결제 → 결과
  - [ ] 당일 트랙: 상세 → 대기열 → 좌석 선택 → 결제 → 결과
  - [ ] 마이 티켓에서 예매 내역 확인
  - [ ] 결제 타이머 만료 시 만료 페이지 이동
  - [ ] 존재하지 않는 URL → 404 페이지
  - [ ] 모바일 반응형 확인

  Closes #5
