### PR TITLE
refactor: 좌석 배치도 2단계 플로우 재구축 (VenueMap + SeatMap)

### DIFF
--- a/src/api/mock/seats.mock.ts
+++ b/src/api/mock/seats.mock.ts
@@ -1,58 +1,112 @@
-import type { Seat, SeatSection } from '@/types/seat'
+import type { Seat, SeatSection, VenueSectionInfo } from '@/types/seat'
 
-function generateSeats(
-  sectionId: string,
-  gradeId: string,
-  rows: string[],
-  seatsPerRow: number,
-  startX: number,
-  startY: number,
+/* ─── Section config for the venue ────────────────────── */
+interface SectionConfig {
+  id: string
+  grade: string
+  rows: number
+  seatsPerRow: number
   soldRatio: number
-): Seat[] {
+}
+
+const FLOOR_SECTIONS: SectionConfig[] = [
+  { id: 'A', grade: 'vip', rows: 6, seatsPerRow: 12, soldRatio: 0.7 },
+  { id: 'B', grade: 'vip', rows: 6, seatsPerRow: 12, soldRatio: 0.8 },
+  { id: 'C', grade: 'vip', rows: 6, seatsPerRow: 12, soldRatio: 0.75 },
+  { id: 'D', grade: 'vip', rows: 6, seatsPerRow: 12, soldRatio: 0.65 },
+  { id: 'E', grade: 'vip', rows: 5, seatsPerRow: 10, soldRatio: 0.6 },
+  { id: 'F', grade: 'vip', rows: 5, seatsPerRow: 10, soldRatio: 0.55 },
+  { id: 'G', grade: 'vip', rows: 5, seatsPerRow: 10, soldRatio: 0.5 },
+  { id: 'H', grade: 'vip', rows: 5, seatsPerRow: 10, soldRatio: 0.45 },
+]
+
+const SECTIONS_1F: SectionConfig[] = Array.from({ length: 15 }, (_, i) => ({
+  id: String(i + 1),
+  grade: 's',
+  rows: 5,
+  seatsPerRow: 10,
+  soldRatio: 0.3,
+}))
+
+const SECTIONS_2F: SectionConfig[] = Array.from({ length: 20 }, (_, i) => ({
+  id: String(i + 24),
+  grade: 'a',
+  rows: 6,
+  seatsPerRow: 12,
+  soldRatio: 0.15,
+}))
+
+const ALL_SECTIONS: SectionConfig[] = [...FLOOR_SECTIONS, ...SECTIONS_1F, ...SECTIONS_2F]
+
+/* ─── Session-level cache ─────────────────────────────── */
+const cache: Record<string, SeatSection> = {}
+
+function buildSectionSeats(config: SectionConfig): SeatSection {
+  const cached = cache[config.id]
+  if (cached) return cached
+
   const seats: Seat[] = []
-  rows.forEach((row, ri) => {
-    for (let i = 1; i <= seatsPerRow; i++) {
+  const rowLabels = Array.from({ length: config.rows }, (_, i) =>
+    String.fromCharCode(65 + i),
+  )
+
+  const startX = Math.max(20, Math.floor((700 - config.seatsPerRow * 28) / 2))
+  const startY = 80
+
+  for (let ri = 0; ri < config.rows; ri++) {
+    const rowLabel = rowLabels[ri] ?? String(ri)
+    for (let si = 1; si <= config.seatsPerRow; si++) {
       const rand = Math.random()
       let status: Seat['status'] = 'available'
-      if (rand < soldRatio) status = 'sold'
-      else if (rand < soldRatio + 0.05) status = 'held'
+      if (rand < config.soldRatio) status = 'sold'
+      else if (rand < config.soldRatio + 0.05) status = 'held'
 
       seats.push({
-        id: `${sectionId}-${row}${i}`,
-        section: sectionId,
-        row,
-        number: i,
-        gradeId,
+        id: `${config.id}-${rowLabel}${si}`,
+        section: config.id,
+        row: rowLabel,
+        number: si,
+        gradeId: config.grade,
         status,
-        x: startX + (i - 1) * 28,
+        x: startX + (si - 1) * 28,
         y: startY + ri * 28,
       })
     }
-  })
-  return seats
+  }
+
+  const section: SeatSection = {
+    id: config.id,
+    label: `${config.id}구역`,
+    seats,
+  }
+
+  cache[config.id] = section
+  return section
 }
 
+/* ─── Public API ──────────────────────────────────────── */
+
+export function getMockVenueSections(): VenueSectionInfo[] {
+  return ALL_SECTIONS.map((config) => {
+    const section = buildSectionSeats(config)
+    const available = section.seats.filter((s) => s.status === 'available').length
+    return {
+      id: config.id,
+      label: config.id,
+      grade: config.grade,
+      totalSeats: section.seats.length,
+      availableSeats: available,
+    }
+  })
+}
+
+export function getMockSectionSeats(sectionId: string): SeatSection[] {
+  const config = ALL_SECTIONS.find((s) => s.id === sectionId)
+  if (!config) return []
+  return [buildSectionSeats(config)]
+}
+
+/** @deprecated Use getMockVenueSections + getMockSectionSeats instead */
 export function getMockSeatSections(): SeatSection[] {
-  return [
-    {
-      id: 'vip',
-      label: 'VIP',
-      seats: generateSeats('vip', 'vip', ['A', 'B', 'C'], 16, 120, 80, 0.7),
-    },
-    {
-      id: 'r',
-      label: 'R석',
-      seats: generateSeats('r', 'r', ['D', 'E', 'F', 'G'], 20, 64, 170, 0.4),
-    },
-    {
-      id: 's',
-      label: 'S석',
-      seats: generateSeats('s', 's', ['H', 'I', 'J', 'K', 'L'], 24, 8, 290, 0.2),
-    },
-    {
-      id: 'a',
-      label: 'A석',
-      seats: generateSeats('a', 'a', ['M', 'N', 'O'], 24, 8, 440, 0.1),
-    },
-  ]
+  return ALL_SECTIONS.map((config) => buildSectionSeats(config))
 }

--- a/src/api/seat.api.ts
+++ b/src/api/seat.api.ts
@@ -1,16 +1,37 @@
-import type { SeatSection, SeatHoldResponse } from '@/types/seat'
+import type { SeatSection, SeatHoldResponse, VenueSectionInfo } from '@/types/seat'
 import client from './client'
-import { getMockSeatSections } from './mock/seats.mock'
+import { getMockSeatSections, getMockVenueSections, getMockSectionSeats } from './mock/seats.mock'
 
 const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true'
 
 export const seatApi = {
+  async getVenueSections(_concertId: string, _dateId: string): Promise<VenueSectionInfo[]> {
+    if (USE_MOCK) return getMockVenueSections()
+    return (await client.get<VenueSectionInfo[]>(`/seats/${_concertId}/${_dateId}/sections`)).data
+  },
+
+  async getSectionSeats(
+    _concertId: string,
+    _dateId: string,
+    sectionId: string,
+  ): Promise<SeatSection[]> {
+    if (USE_MOCK) return getMockSectionSeats(sectionId)
+    return (
+      await client.get<SeatSection[]>(`/seats/${_concertId}/${_dateId}/${sectionId}`)
+    ).data
+  },
+
   async getSeatMap(_concertId: string, _dateId: string): Promise<SeatSection[]> {
     if (USE_MOCK) return getMockSeatSections()
     return (await client.get<SeatSection[]>(`/seats/${_concertId}/${_dateId}`)).data
   },
 
-  async holdSeat(concertId: string, dateId: string, seatId: string, token: string): Promise<SeatHoldResponse> {
+  async holdSeat(
+    concertId: string,
+    dateId: string,
+    seatId: string,
+    token: string,
+  ): Promise<SeatHoldResponse> {
     if (USE_MOCK) {
       return {
         holdId: `hold-${Date.now()}`,
@@ -18,6 +39,8 @@ export const seatApi = {
         seatId,
       }
     }
-    return (await client.post<SeatHoldResponse>('/seats/hold', { concertId, dateId, seatId, token })).data
+    return (
+      await client.post<SeatHoldResponse>('/seats/hold', { concertId, dateId, seatId, token })
+    ).data
   },
 }


### PR DESCRIPTION
   ## Summary
  - 좌석 선택 화면을 2단계 플로우로 재구축 (구역 선택 → 좌석 선택)
  - SVG 극좌표 기반 VenueMap 컴포넌트 신규 추가
  - SeatMap, SeatsPage, API/타입/목데이터 수정

  ## Changes
  - `VenueMap.vue` — 구역 선택 컴포넌트 (신규)
  - `SeatsPage.vue` — 2단계 플로우 통합
  - `SeatMap.vue` — 선택 구역 기반 좌석 표시
  - `seat.api.ts` — 구역 조회 API 추가
  - `seat.ts` — 구역 관련 타입 추가
  - `seats.mock.ts` — 구역별 목 데이터 확장

  ## 스크린샷 
  - 목표 
<img width="1026" height="940" alt="스크린샷 2026-02-10 오후 7 31 02" src="https://github.com/user-attachments/assets/c06232ad-3f35-4cc4-863e-b018f32903c4" />

  - 실제 완성 
<img width="723" height="729" alt="스크린샷 2026-02-11 오전 11 28 39" src="https://github.com/user-attachments/assets/8212f3c9-f434-437b-be14-40c728bdbe30" />


  ## Related Issue
  - closes #7